### PR TITLE
Allow filtering own tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ $ git start
 # shows lists of tasks (excluding icebox) - choosing one starts/assigns the task on pt and
 # automatically creates and checks out a new branch.
 
-$ git start --include-icebox
-# same as git start, including contents of icebox
+$ git start --filter=icebox
+# same as git start, showing contents of icebox
+
+$ git start --filter=me
+# shows only own tasks
 
 $ git finish
 # pushes branch, finishes task on pt, and opens new pull request

--- a/lib/pt-flow.rb
+++ b/lib/pt-flow.rb
@@ -6,6 +6,7 @@ require 'pt-flow/task_row'
 require 'pt-flow/tasks_table'
 require 'pt-flow/ui'
 require 'hirb-colors'
+require 'trollop'
 
 module PT
   module Flow

--- a/lib/pt-flow/ui.rb
+++ b/lib/pt-flow/ui.rb
@@ -6,17 +6,20 @@ module PT::Flow
     end
 
     def start
+      @options = Trollop::options(@params.dup) do
+        opt :filter, 'Allow filtering tasks', type: :string
+      end
+
       if @params[0] && !@params[0].start_with?('--')
         task = create
       else
-        filter = 'unstarted,started'
-        filter += ',unscheduled' if @params.include?('--include-icebox')
-        table = TasksTable.new(@project.stories.all(:current_state => filter))
+        filter = filters[@options[:filter]] || { current_state: 'unstarted,started' }
+        table = TasksTable.new @project.stories.all(filter)
         title("Available tasks in #{project_to_s}")
         task = select("Please select a task to start working on", table)
       end
       estimate_task(task, ask("How many points do you estimate for it? (#{@project.point_scale})")) if task.estimate && task.estimate < 0
-      assign_task(task, @local_config[:user_name])
+      assign_task(task, user_name)
       start_task(task)
       run("git checkout -b #{Branch.from_task(task)}")
     end
@@ -25,7 +28,7 @@ module PT::Flow
       name = @params[0] || ask("Name for the new story:")
       types = { 'c' => 'chore', 'b' => 'bug', 'f' => 'feature' }
       task_type = types[ask('Type? (c)hore, (b)ug, (f)eature')]
-      task = @project.stories.create(name: name, requested_by: @local_config[:user_name], story_type: task_type)
+      task = @project.stories.create(name: name, requested_by: user_name, story_type: task_type)
       if task.errors.any?
         error(task.errors.errors)
       else
@@ -35,10 +38,15 @@ module PT::Flow
     end
 
     def finish
+      @options = Trollop::options(@params.dup) do
+        opt :deliver, 'Merge branch automatically'
+        opt :wip, 'submits [WIP] pull request'
+      end
+
       run "git push origin #{branch} -u"
-      if @params.include?('--deliver')
+      if @options[:deliver]
         deliver!
-      elsif @params.include?('--wip')
+      elsif @options[:wip]
         open_url pull_request_url('[WIP]')
       else
         finish_task current_task
@@ -67,64 +75,75 @@ module PT::Flow
 
     private
 
-    def branch
-      @branch ||= Branch.current
-    end
-
-    def repo
-      @repo ||= Repo.new
-    end
-
-    def assign_task(task, owner)
-      result = @client.assign_task(@project, task, owner)
-      if result.errors.any?
-        error(result.errors.errors)
-      else
-        congrats("Task assigned to #{owner}")
+      def branch
+        @branch ||= Branch.current
       end
-    end
 
-    def current_task
-      PivotalTracker::Story.find(branch.task_id, @project.id)
-    end
-
-    def task_title
-      task_title = current_task.name.gsub('"',"'") + " [Delivers ##{current_task.id}]"
-      task_title = 'Bugfix: ' + task_title if current_task.story_type == 'bug'
-      task_title
-    end
-
-    def pull_request_url(prefix = nil)
-      title = URI.escape "#{prefix} #{task_title}".strip
-      repo.url + "/compare/#{branch.target}...#{branch}?expand=1&title=#{title}"
-    end
-
-    def deliver!
-      run "hub pull-request -b #{branch.target} -h #{repo.user}:#{branch} -m \"#{task_title}\""
-      finished_branch = branch
-      title = task_title
-      run "git checkout #{finished_branch.target}"
-      run "git pull"
-      run "git merge #{finished_branch} --no-ff -m \"#{title}\""
-      run "git push origin #{finished_branch.target}"
-    end
-
-    def open_url(url)
-      if ENV['BROWSER'] == 'echo'
-        title url
-      else
-        run "open \"#{url}\""
+      def repo
+        @repo ||= Repo.new
       end
-    end
 
-    def run(command)
-      title(command)
-      error("Error running: #{command}") unless system(command)
-    end
+      def assign_task(task, owner)
+        result = @client.assign_task(@project, task, owner)
+        if result.errors.any?
+          error(result.errors.errors)
+        else
+          congrats("Task assigned to #{owner}")
+        end
+      end
 
-    def error(*msg)
-      super
-      exit(false)
-    end
+      def current_task
+        PivotalTracker::Story.find(branch.task_id, @project.id)
+      end
+
+      def task_title
+        task_title = current_task.name.gsub('"',"'") + " [Delivers ##{current_task.id}]"
+        task_title = 'Bugfix: ' + task_title if current_task.story_type == 'bug'
+        task_title
+      end
+
+      def pull_request_url(prefix = nil)
+        title = URI.escape "#{prefix} #{task_title}".strip
+        repo.url + "/compare/#{branch.target}...#{branch}?expand=1&title=#{title}"
+      end
+
+      def deliver!
+        run "hub pull-request -b #{branch.target} -h #{repo.user}:#{branch} -m \"#{task_title}\""
+        finished_branch = branch
+        title = task_title
+        run "git checkout #{finished_branch.target}"
+        run "git pull"
+        run "git merge #{finished_branch} --no-ff -m \"#{title}\""
+        run "git push origin #{finished_branch.target}"
+      end
+
+      def open_url(url)
+        if ENV['BROWSER'] == 'echo'
+          title url
+        else
+          run "open \"#{url}\""
+        end
+      end
+
+      def run(command)
+        title(command)
+        error("Error running: #{command}") unless system(command)
+      end
+
+      def error(*msg)
+        super
+        exit(false)
+      end
+
+      def filters
+        {
+          'icebox' => { current_state: 'unscheduled' },
+          'me' => { current_state: 'unstarted,started', owner: user_name }
+        }
+      end
+
+      def user_name
+        @local_config[:user_name]
+      end
   end
 end

--- a/lib/pt-flow/version.rb
+++ b/lib/pt-flow/version.rb
@@ -1,5 +1,5 @@
 module PT
   module Flow
-    VERSION = '2.5.0'
+    VERSION = '2.6.0'
   end
 end

--- a/pt-flow.gemspec
+++ b/pt-flow.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'pivotal-tracker'
   gem.add_dependency 'activesupport'
   gem.add_dependency 'hirb-colors'
+  gem.add_dependency 'trollop', '~> 2.1'
 
   gem.add_development_dependency 'rspec', '~> 2.9'
   gem.add_development_dependency 'webmock'

--- a/spec/lib/pt-flow/ui_spec.rb
+++ b/spec/lib/pt-flow/ui_spec.rb
@@ -73,14 +73,20 @@ module PT::Flow
         end
       end
 
-      context 'given --include-icebox' do
-        it "it includes icebox stories" do
+      context 'given various filters' do
+        before do
           prompt.should_receive(:ask).with("Please select a task to start working on (1-14, 'q' to exit)".bold).and_return('2')
           prompt.should_receive(:ask).with("How many points do you estimate for it? (0,1,2,3)".bold).and_return('3')
+        end
 
-          UI.new('start', ['--include-icebox'])
+        it "it allows showing icebox contents" do
+          UI.new('start', ['--filter=icebox'])
+          WebMock.should have_requested(:get, "#{endpoint}/projects/102622/stories?filter=current_state:unscheduled")
+        end
 
-          WebMock.should have_requested(:get, "#{endpoint}/projects/102622/stories?filter=current_state:unstarted,started,unscheduled")
+        it "it allows showing your own tasks" do
+          UI.new('start', ['--filter=me'])
+          WebMock.should have_requested(:get, "#{endpoint}/projects/102622/stories?filter=current_state:unstarted,started+owner:Jon+Mischo")
         end
       end
     end


### PR DESCRIPTION
Provides one consistent `--filter` option that can be given different options to filter tasks. New options are:

```bash
$ git start --filter=icebox
# shows only contents of icebox

$ git start --filter=me
# shows only own tasks
```