### PR TITLE
when working on a release branch, automatically prefix with branch name [Delivers #109952282]

### DIFF
--- a/lib/pt-flow/branch.rb
+++ b/lib/pt-flow/branch.rb
@@ -20,6 +20,10 @@ module PT::Flow
       name.split('.').first
     end
 
+    def release_branch?
+      target != 'master'
+    end
+
     def task_id
       name[/\d+$/] || ''
     end

--- a/lib/pt-flow/ui.rb
+++ b/lib/pt-flow/ui.rb
@@ -46,10 +46,8 @@ module PT::Flow
       run "git push origin #{branch} -u"
       if @options[:deliver]
         deliver!
-      elsif @options[:wip]
-        open_url pull_request_url('[WIP]')
       else
-        finish_task current_task
+        finish_task(current_task) unless @options[:wip]
         open_url pull_request_url
       end
     end
@@ -102,9 +100,16 @@ module PT::Flow
         task_title
       end
 
-      def pull_request_url(prefix = nil)
+      def pull_request_url
         title = URI.escape "#{prefix} #{task_title}".strip
         repo.url + "/compare/#{branch.target}...#{branch}?expand=1&title=#{title}"
+      end
+
+      def prefix
+        prefixes = []
+        prefixes << "[WIP]" if @options[:wip]
+        prefixes << "[#{branch.target.titleize}]" if branch.release_branch?
+        prefixes.join(" ")
       end
 
       def deliver!

--- a/spec/lib/pt-flow/ui_spec.rb
+++ b/spec/lib/pt-flow/ui_spec.rb
@@ -106,17 +106,17 @@ module PT::Flow
         context 'no options' do
           it "pushes the current branch to origin, flags the story as finished, and opens github pull request URL" do
             UI.any_instance.should_receive(:run).with('git push origin new_feature.this-is-for-comments.4460038 -u')
-            UI.any_instance.should_receive(:run).with("open \"https://github.com/cookpad/pt-flow/compare/new_feature...new_feature.this-is-for-comments.4460038?expand=1&title=This%20is%20for%20comments%20[Delivers%20%234460038]\"")
+            UI.any_instance.should_receive(:run).with("open \"https://github.com/cookpad/pt-flow/compare/new_feature...new_feature.this-is-for-comments.4460038?expand=1&title=[New%20Feature]%20This%20is%20for%20comments%20[Delivers%20%234460038]\"")
             UI.new('finish')
             current_branch.should == 'new_feature.this-is-for-comments.4460038'
             WebMock.should have_requested(:put, "#{endpoint}/projects/102622/stories/4460038").with(body: /<current_state>finished<\/current_state>/)
           end
         end
 
-        context 'give option --wip' do
+        context 'given option --wip' do
           it "pushes the current branch to origin, and opens github [WIP] pull request URL" do
             UI.any_instance.should_receive(:run).with('git push origin new_feature.this-is-for-comments.4460038 -u')
-            UI.any_instance.should_receive(:run).with("open \"https://github.com/cookpad/pt-flow/compare/new_feature...new_feature.this-is-for-comments.4460038?expand=1&title=[WIP]%20This%20is%20for%20comments%20[Delivers%20%234460038]\"")
+            UI.any_instance.should_receive(:run).with("open \"https://github.com/cookpad/pt-flow/compare/new_feature...new_feature.this-is-for-comments.4460038?expand=1&title=[WIP]%20[New%20Feature]%20This%20is%20for%20comments%20[Delivers%20%234460038]\"")
             UI.new('finish', ['--wip'])
           end
         end
@@ -137,7 +137,7 @@ module PT::Flow
 
     context 'https repo' do
       before do
-        system('git checkout -B new_feature')
+        system('git checkout -B master')
         system('git remote rm origin')
         system('git remote add origin https://github.com/balvig/pt-flow.git')
 
@@ -146,8 +146,8 @@ module PT::Flow
       end
 
       it "pushes the current branch to origin, flags the story as finished, and opens a github pull request" do
-        UI.any_instance.should_receive(:run).with('git push origin new_feature.this-is-for-comments.4460038 -u')
-        UI.any_instance.should_receive(:run).with("open \"https://github.com/balvig/pt-flow/compare/new_feature...new_feature.this-is-for-comments.4460038?expand=1&title=This%20is%20for%20comments%20[Delivers%20%234460038]\"")
+        UI.any_instance.should_receive(:run).with('git push origin master.this-is-for-comments.4460038 -u')
+        UI.any_instance.should_receive(:run).with("open \"https://github.com/balvig/pt-flow/compare/master...master.this-is-for-comments.4460038?expand=1&title=This%20is%20for%20comments%20[Delivers%20%234460038]\"")
         UI.new('finish')
       end
     end


### PR DESCRIPTION
``` bash
git checkout -b "my_release"
git start "Awesome new part of release" # => my_release.awesome-new-part-of-release.12345
git finish # => Opens PR with "[My Release] Awesome new part of release
```
